### PR TITLE
Update Brackets to 1.14.1

### DIFF
--- a/io.brackets.Brackets.appdata.xml
+++ b/io.brackets.Brackets.appdata.xml
@@ -25,6 +25,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.14.1" date="2019-12-05"/>
     <release version="1.14" date="2019-05-02"/>
     <release version="1.13" date="2018-06-18"/>
   </releases>

--- a/io.brackets.Brackets.json
+++ b/io.brackets.Brackets.json
@@ -42,13 +42,13 @@
       "sources": [
         {
           "type": "file",
-          "url": "https://github.com/adobe/brackets/releases/download/release-1.14/Brackets.Release.1.14.64-bit.deb",
-          "sha256": "4df8490efb8a35ff93ac6975655ab4af9a56547eb4a346514803aa2e1f20f30e"
+          "url": "https://github.com/adobe/brackets/releases/download/release-1.14.1/Brackets.Release.1.14.1.64-bit.deb",
+          "sha256": "dd8346ee7061e8820ecb7859f5cdccb6f199b144dd17192c217dd49512c4452b"
         },
         {
           "type": "file",
-          "url": "https://github.com/adobe/brackets/releases/download/release-1.14/Brackets.Release.1.14.32-bit.deb",
-          "sha256": "2c0053fb50d1d79071d455a35fbe6f4f9cdb3cd1edf90bec55a4c0c90661a1f1"
+          "url": "https://github.com/adobe/brackets/releases/download/release-1.14.1/Brackets.Release.1.14.1.32-bit.deb",
+          "sha256": "6ef1567b75a197236b3d35785afa744752a28b74cfa51b93b7b78d0a50acbfd4"
         },
         {
           "type": "file",
@@ -56,8 +56,8 @@
         },
         {
           "type": "file",
-          "url": "https://github.com/adobe/brackets/archive/release-1.14.tar.gz",
-          "sha256": "11dd7edcdacfe772d9ad2f824aa605972f0a3a6caab62f4957682287c1752838"
+          "url": "https://github.com/adobe/brackets/archive/release-1.14.1.tar.gz",
+          "sha256": "9a07fc80a155d2490be4eff77a2622539012325cef18e89305b8bc45c4c3833d"
         }
       ]
     }


### PR DESCRIPTION
1.14.1 fixes a security issue in Brackets, and while 1.14.2 is out, it is marked as being "[targeted for Mac and Windows users only](https://github.com/adobe/brackets/releases/tag/release-1.14.2)".